### PR TITLE
[CF] moved logging and return to inner scope

### DIFF
--- a/src/HttpTracer/HttpTracerHandler.cs
+++ b/src/HttpTracer/HttpTracerHandler.cs
@@ -72,20 +72,17 @@ namespace HttpTracer
         {
             await LogHttpRequest(request).ConfigureAwait(false);
 
-            HttpResponseMessage response;
             try
             {
-                response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                await LogHttpResponse(response).ConfigureAwait(false);
+                return response;
             }
             catch (Exception ex)
             {
                 LogHttpException(request, ex);
                 throw;
             }
-
-            await LogHttpResponse(response).ConfigureAwait(false);
-
-            return response;
         }
 
         private static Task<string> GetRequestContent(HttpRequestMessage request)


### PR DESCRIPTION
since the catch re-throws, there's really no point in leaving the logging and return result outside the try/catch. Moving it into the inner scope helps readability and keeps things tighter.